### PR TITLE
server: Allow HTTPS (for Secrets Manager) and DB traffic between subnets

### DIFF
--- a/server/template.yaml
+++ b/server/template.yaml
@@ -143,17 +143,92 @@ Resources:
     Type: AWS::EC2::NetworkAcl
     Properties:
       VpcId: !Ref VPC
-  # no NACL entries so we deny all inbound AND outbound traffic from the subnets.
-  PrivateSubnet1NetworkACL:
+  PrivateSubnet1NetworkAclAssociation:
     Type: AWS::EC2::SubnetNetworkAclAssociation
     Properties:
       SubnetId: !Ref PrivateSubnet1
       NetworkAclId: !Ref NetworkACL
-  PrivateSubnet2NetworkACL:
+  PrivateSubnet2NetworkAclAssociation:
     Type: AWS::EC2::SubnetNetworkAclAssociation
     Properties:
       SubnetId: !Ref PrivateSubnet2
       NetworkAclId: !Ref NetworkACL
+  OutboundDbRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref NetworkACL
+      RuleNumber: 100
+      Protocol: 6  # TCP
+      Egress: true
+      RuleAction: allow
+      CidrBlock: !Ref VpcCIDR
+      PortRange:
+        From: !Ref DatabasePort
+        To: !Ref DatabasePort
+  InboundDbRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref NetworkACL
+      RuleNumber: 100
+      Protocol: 6  # TCP
+      Egress: false
+      RuleAction: allow
+      CidrBlock: !Ref VpcCIDR
+      PortRange:
+        From: !Ref DatabasePort
+        To: !Ref DatabasePort
+  OutboundLambdaRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref NetworkACL
+      RuleNumber: 110
+      Protocol: 6  # TCP
+      Egress: true
+      RuleAction: allow
+      CidrBlock: !Ref VpcCIDR
+      # need to send packets back to Lambdas which start connections from an ephemeral port range.
+      # See https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-ephemeral-ports
+      PortRange:
+        From: 1024
+        To: 65535
+  InboundLambdaRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref NetworkACL
+      RuleNumber: 110
+      Protocol: 6  # TCP
+      Egress: false
+      RuleAction: allow
+      CidrBlock: !Ref VpcCIDR
+      # need to send packets back to Lambdas which start connections from an ephemeral port range.
+      # See https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-ephemeral-ports
+      PortRange:
+        From: 1024
+        To: 65535
+  OutboundSecretsRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref NetworkACL
+      RuleNumber: 150
+      Protocol: 6  # TCP
+      Egress: true
+      RuleAction: allow
+      CidrBlock: !Ref VpcCIDR
+      PortRange:
+        From: 443
+        To: 443
+  InboundSecretsRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref NetworkACL
+      RuleNumber: 150
+      Protocol: 6  # TCP
+      Egress: false
+      RuleAction: allow
+      CidrBlock: !Ref VpcCIDR
+      PortRange:
+        From: 443
+        To: 443
 
   LambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Some lambda function executions started in one subnet but accessed the DB which was in the other subnet and resulted in timeouts since the NACL rejected the flow.

* Specify TCP protocol for NACL entries

* Widen NACLs to allow ephemeral ports

* Widen NACLs to whole VPC

Having more granular NACL entries is not worth the boilerplate.