### PR TITLE
server: Prevent VPCFlowLog from being deleted

### DIFF
--- a/server/template.yaml
+++ b/server/template.yaml
@@ -44,6 +44,7 @@ Resources:
       #     Value: !Ref EnvironmentName
   VPCFlowLog:
     Type: AWS::EC2::FlowLog
+    DeletionPolicy: Retain
     Properties:
       ResourceType: VPC
       ResourceId: !Ref VPC


### PR DESCRIPTION
I keep getting errors since our AWS account is forbidden from deleting flow logs.