### PR TITLE
server: Actually prevent VPCFlowLog from being deleted

### DIFF
--- a/server/template.yaml
+++ b/server/template.yaml
@@ -44,6 +44,7 @@ Resources:
       #     Value: !Ref EnvironmentName
   VPCFlowLog:
     Type: AWS::EC2::FlowLog
+    UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
     Properties:
       ResourceType: VPC


### PR DESCRIPTION
I got a warning from `sam validate` (I don't remember if it was `--lint` or no `--lint`):

    W3011 Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/VPCFlowLog from deletion